### PR TITLE
feat: create health route

### DIFF
--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", async (req, res) => {
+  const payload = {
+    ok: true,
+    atlasUriEnv: !!process.env.ATLAS_URI,
+  };
+  res.send(payload).status(200);
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import sourceMapSupport from 'source-map-support';
 import cors from "cors";
+import health from "./routes/health.js";
 import sessions from "./routes/session.js";
 
 sourceMapSupport.install();
@@ -10,6 +11,7 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
+app.use("/health", health);
 app.use("/session", sessions);
 
 // start the Express server


### PR DESCRIPTION
Create a health route to assess the health of the server.

Response payload includes an `ok` parameter, always true, and also an `atlasUriEnv` param, to help assess whether envs have been imported correctly.